### PR TITLE
Support extensions to body and headers of OAuth 2 token requests

### DIFF
--- a/src/oauth-shim.js
+++ b/src/oauth-shim.js
@@ -24,7 +24,7 @@ module.exports = oauth_shim;
 // Map default options
 function oauth_shim(req, res, next) {
 	return oauth_shim.request(req, res, next);
-};
+}
 
 // Get the credentials object for managing the getting and setting of credentials.
 var credentials = require('./credentials');
@@ -55,7 +55,8 @@ oauth_shim.request = function(req, res, next) {
 // Append data to the request object to hand over to the 'redirect' handler
 oauth_shim.interpret = function(req, res, next) {
 
-	var self = oauth_shim;
+	var self = oauth_shim,
+		options = self.options || {};
 
 	// if the querystring includes
 	// An authentication 'code',
@@ -102,7 +103,7 @@ oauth_shim.interpret = function(req, res, next) {
 
 				// OAuth Login
 				redirect(req, p.redirect_uri, session, next);
-			});
+			}, options.oauth2);
 
 		}, function(error) {
 			redirect(req, p.redirect_uri, error, next);
@@ -134,7 +135,7 @@ oauth_shim.interpret = function(req, res, next) {
 				}
 
 				redirect(req, loc, session, next);
-			});
+			},options.oauth1);
 
 		}, function(error) {
 			redirect(req, p.redirect_uri, error, next);

--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -7,10 +7,15 @@ var request = require('./utils/request');
 var param = require('./utils/param');
 var url = require('url');
 
-module.exports = function(p, callback) {
+module.exports = function(p, callback, options) {
+
+	if (!options) options = {};
 
 	// Make the OAuth2 request
-	var post = null;
+	var post = null,
+		extendRequestBody = options.extendRequestBody,
+		extendRequestHeaders = options.extendRequestHeaders;
+
 	if (p.code) {
 		post = {
 			code: p.code,
@@ -29,6 +34,10 @@ module.exports = function(p, callback) {
 		};
 	}
 
+	if (extendRequestBody) {
+		extendRequestBody(post);
+	}
+
 	// Get the grant_url
 	var grant_url = p.oauth ? p.oauth.grant : false;
 
@@ -43,17 +52,24 @@ module.exports = function(p, callback) {
 	post = param(post, function(r) {return r;});
 
 	// Create the request
-	var r = url.parse(grant_url);
+	var r = url.parse(grant_url),
+		requestHeaders = {
+			'Content-length': post.length,
+			'Content-type': 'application/x-www-form-urlencoded'
+		};
+
 	r.method = 'POST';
-	r.headers = {
-		'Content-length': post.length,
-		'Content-type': 'application/x-www-form-urlencoded'
-	};
 
 	// Workaround for Vimeo, which requires an extra Authorization header
 	if (p.authorisation === 'header') {
-		r.headers.Authorization = 'basic ' + new Buffer(p.client_id + ':' + p.client_secret).toString('base64');
+		requestHeaders.Authorization = 'basic ' + new Buffer(p.client_id + ':' + p.client_secret).toString('base64');
 	}
+
+	if (extendRequestHeaders) {
+		extendRequestHeaders(requestHeaders);
+	}
+
+	r.headers = requestHeaders;
 
 	//opts.body = post;
 	request(r, post, function(err, res, body, data) {

--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -35,7 +35,7 @@ module.exports = function(p, callback, options) {
 	}
 
 	if (extendRequestBody) {
-		extendRequestBody(post);
+		extendRequestBody(post,p);
 	}
 
 	// Get the grant_url
@@ -66,7 +66,7 @@ module.exports = function(p, callback, options) {
 	}
 
 	if (extendRequestHeaders) {
-		extendRequestHeaders(requestHeaders);
+		extendRequestHeaders(requestHeaders,p);
 	}
 
 	r.headers = requestHeaders;


### PR DESCRIPTION
This PR enables users of node-oauth-shim to add hook functions which enable additional headers or body parameters to be injected into OAuth 2 access token requests just prior to sending the request. This is necessary for various services. For example, the existing workaround for Vimeo where a Authorization header containing BasicAuth could be accomplished at a per-service level by leveraging the `extendRequestHeaders()` hook function. As far as `extendRequestBody()`, I have found this is necessary for some Microsoft ACS services, such as SharePoint Online, which require a "resource" parameter to be added into the access token request body. 

For example, someone wishing to extend the request body to add an additional "resource" parameter could do something like this:

```
oauthshim.options = {
   oauth2 : {
      extendRequestBody: function(payload,params){
          // Single parameter merge
          if (params.extra_query_string_param === "foo") {
             payload.resource = "foobar";
         } else {
         // Multi-parameter merge
           _.merge(payload,{
              "foo":"bar",
              "bar":"baz"
          });
      }
   }
};
   
```

Where `extra_query_string_param` is a Query String parameter passed in to the initial token request to the proxy.