### PR TITLE
OAuth2 access token request body parameters should be URL-encoded

### DIFF
--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -17,7 +17,7 @@ module.exports = function(p, callback) {
 			client_id: p.client_id || p.id,
 			client_secret: p.client_secret,
 			grant_type: 'authorization_code',
-			redirect_uri: encodeURIComponent(p.redirect_uri)
+			redirect_uri: p.redirect_uri
 		};
 	}
 	else if (p.refresh_token) {
@@ -40,7 +40,7 @@ module.exports = function(p, callback) {
 	}
 
 	// Convert the post object literal to a string
-	post = param(post, function(r) {return r;});
+	post = param(post);
 
 	// Create the request
 	var r = url.parse(grant_url);


### PR DESCRIPTION
According to the OAuth 2 spec, section 4.1.3, parameters sent in the Access Token Request body should be URL encoded. Currently the logic in node-oauth-shim is explicitly _not_ encoding the parameter values, which causes problems when parameters such as `client_id` or `client_secret` contain characters that must be URL encoded, and which target token endpoints are expecting to receive URL-encoded.