### PR TITLE
allows for authorization and accept headers - proxy.js

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -78,7 +78,7 @@ exports.proxy = function(req, res, options, buffer) {
 	// Loop through all req.headers
 	for (var header in req.headers) {
 		// Is this a custom header?
-		if (header.match(/^(x-|content-type)/i)) {
+		if (header.match(/^(x-|content-type|authorization|accept)/i)) {
 			options.headers[header] = req.headers[header];
 		}
 	}


### PR DESCRIPTION
allows for authorization and accept headers in proxy requests to be forwarded to API/OAuth2 servers